### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/wandam/701fbd6e-bcf2-4aae-959f-8c6813b3e73f/e9e44ad7-969d-4b91-9c21-7247a87f6dc3/_apis/work/boardbadge/a621b9e5-f84a-457c-b491-2fc5c4778f61)](https://dev.azure.com/wandam/701fbd6e-bcf2-4aae-959f-8c6813b3e73f/_boards/board/t/e9e44ad7-969d-4b91-9c21-7247a87f6dc3/Microsoft.RequirementCategory)
 # Your GitHub Learning Lab Repository for Introducing GitHub
 
 Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through. See a word you don't understand? We've included an emoji 📖 next to some key terms. Click on it to see its definition.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#7](https://dev.azure.com/wandam/701fbd6e-bcf2-4aae-959f-8c6813b3e73f/_workitems/edit/7). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.